### PR TITLE
Make fields public in ApproachBodyEvent

### DIFF
--- a/src/modules/logs/content/log_event_content/approach_body_event.rs
+++ b/src/modules/logs/content/log_event_content/approach_body_event.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "PascalCase")]
 pub struct ApproachBodyEvent {
-    star_system: String,
-    body: String,
+    pub star_system: String,
+    pub body: String,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The fields in on the `ApproachBodyEvent` type are set to private. This seems like a mistake, so I changed that.