### PR TITLE
Derive `Serialize` for `JournalEvent`

### DIFF
--- a/src/modules/journal/models/journal_event.rs
+++ b/src/modules/journal/models/journal_event.rs
@@ -1,6 +1,7 @@
 use crate::journal::JournalEventKind;
+use serde::Serialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JournalEvent {
     /// Indicates whether the event was fired from a change in the journal directory or whether
     /// it's an event from a log file other than the current one.

--- a/src/modules/journal/models/journal_event_kind.rs
+++ b/src/modules/journal/models/journal_event_kind.rs
@@ -8,10 +8,11 @@ use crate::nav_route::NavRoute;
 use crate::ship_locker::ShipLocker;
 use crate::shipyard::Shipyard;
 use crate::status::Status;
+use serde::Serialize;
 
 /// This event is fired from the [LiveJournalDirReader] when any change happens in the journal
 /// directory and includes all the possible models that could have been updated.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 // The large enum variant is allowed here as this is usually allocated by the reader anyway and
 // adding another box here wouldn't be that useful. Also even though it's large, it's not huge.
 #[allow(clippy::large_enum_variant)]


### PR DESCRIPTION
Small addition, I find myself needing to serialize an `JournalEvent`, but it's not implemented.