### PR TITLE
Make `JournalDirWatcherError` publicly accessible

### DIFF
--- a/src/modules/journal/asynchronous.rs
+++ b/src/modules/journal/asynchronous.rs
@@ -1,3 +1,4 @@
+pub use live_journal_dir_reader::JournalDirWatcherError;
 pub use live_journal_dir_reader::LiveJournalDirReader;
 
 mod live_journal_dir_reader;

--- a/src/modules/journal/blocking.rs
+++ b/src/modules/journal/blocking.rs
@@ -1,3 +1,4 @@
+pub use live_journal_dir_reader::JournalDirWatcherError;
 pub use live_journal_dir_reader::LiveJournalDirReader;
 
 mod live_journal_dir_reader;


### PR DESCRIPTION
yo,

Currently `JournalDirWatcherError` is not accessible as the `live_journal_dir_reader` isn’t `pub`. Not sure if you’d rather make the entire module public, or just reexport the error. This PR does the latter but either works for me!

