### PR TITLE
fix typo `srv_handbreak` -> `srv_handbrake`

### DIFF
--- a/src/modules/status/models/flags.rs
+++ b/src/modules/status/models/flags.rs
@@ -69,8 +69,8 @@ impl Flags {
         self.0 & 2048 != 0
     }
 
-    /// Whether the SRV handbreak is currently on.
-    pub fn srv_handbreak(&self) -> bool {
+    /// Whether the SRV handbrake is currently on.
+    pub fn srv_handbrake(&self) -> bool {
         self.0 & 4096 != 0
     }
 


### PR DESCRIPTION
small typo fix. at least it's still okay to make *break*ing changes now, right? xd