### PR TITLE
Fix: Haematite commodity

### DIFF
--- a/src/modules/trading/models/commodity.rs
+++ b/src/modules/trading/models/commodity.rs
@@ -583,6 +583,7 @@ impl Commodity {
             "gallite" => Commodity::Gallite,
             "goslarite" => Commodity::Goslarite,
             "grandidierite" => Commodity::Grandidierite,
+            "haematite" => Commodity::Haematite,
             "indite" => Commodity::Indite,
             "jadeite" => Commodity::Jadeite,
             "lepidolite" => Commodity::Lepidolite,


### PR DESCRIPTION
Fixes error when parsing the line `{ "timestamp":"2025-06-08T18:51:46Z", "event":"ProspectedAsteroid", "Materials":[ { "Name":"uraninite", "Proportion":19.868727 }, { "Name":"haematite", "Proportion":23.365101 } ], "Content":"$AsteroidMaterialContent_Low;", "Content_Localised":"Material Content: Low", "Remaining":100.000000 }`.

I don't include the journal in this PR, as there is another error which I struggle to fix. I will make a separate PR for it.