### PR TITLE
misc: copy over error, async_iter and log_iter impls from reader-refator branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,12 +42,125 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f7e37c0ed80b2a977691c47dae8625cfb21e205827106c64f7c588766b2e50"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener 5.4.0",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-mutex"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
- "event-listener",
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.0",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -71,6 +184,18 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -104,6 +229,19 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
 
 [[package]]
 name = "bumpalo"
@@ -145,6 +283,15 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -202,19 +349,33 @@ dependencies = [
 name = "ed-journals"
 version = "0.11.1"
 dependencies = [
+ "async-fs",
  "async-mutex",
  "chrono",
  "directories",
+ "futures",
  "kinded",
  "lazy_static",
  "notify",
  "regex",
  "serde",
  "serde_json",
+ "smol",
  "strum",
  "thiserror",
  "tokio",
  "tokio-test",
+ "tokio-util",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -222,6 +383,33 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.0",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filetime"
@@ -245,10 +433,106 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-core"
-version = "0.3.30"
+name = "futures"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -272,6 +556,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "iana-time-zone"
@@ -380,9 +670,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libredox"
@@ -394,6 +684,12 @@ dependencies = [
  "libc",
  "redox_syscall",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
@@ -478,10 +774,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "polling"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee9b2fa7a4517d2c91ff5bc6c297a427a96749d15f98fcdbb22c05571a4d4b7"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -557,6 +890,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +960,38 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
 
 [[package]]
 name = "strum"
@@ -701,6 +1079,20 @@ dependencies = [
  "futures-core",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -805,6 +1197,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +1218,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -846,11 +1253,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -866,6 +1290,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +1306,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -890,10 +1326,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -908,6 +1356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +1372,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -932,6 +1392,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,3 +1408,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,4 @@ allow-unknown = []
 # parsing errors. In such cases, PRs with affected Journal files/events are appreciated :)
 legacy = []
 async-fs = ["dep:async-fs"]
+tokio = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,16 +28,13 @@ tokio = { version = "1.37.0", features = [
 async-mutex = { version = "1.4.0", optional = true }
 strum = { version = "0.26.2", features = ["derive"] }
 futures = { version = "0.3.31", optional = true }
-async-fs = { version = "2.1.2", optional = true }
 tokio-util = { version = "0.7.14", features = ["compat"], optional = true }
-
 directories = "5.0.1"
 
 [dev-dependencies]
 tokio-test = "0.4.4"
 smol = "2.0.2"
 async-fs = { version = "2.1.2" }
-
 
 [package.metadata.docs.rs]
 all-features = true
@@ -50,5 +47,4 @@ allow-unknown = []
 # Enables loading Journal files from before game version 4. Not fully supported and may lead to
 # parsing errors. In such cases, PRs with affected Journal files/events are appreciated :)
 legacy = []
-async-fs = ["dep:async-fs"]
-tokio = []
+tokio = ["dep:tokio-util"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,24 @@ serde_json = "1.0.116"
 kinded = "0.3.0"
 lazy_static = "1.4.0"
 notify = "6.1.1"
-tokio = { version = "1.37.0", features = ["fs", "sync", "io-util"], default-features = false, optional = true }
+tokio = { version = "1.37.0", features = [
+    "fs",
+    "sync",
+    "io-util",
+], default-features = false, optional = true }
 async-mutex = { version = "1.4.0", optional = true }
 strum = { version = "0.26.2", features = ["derive"] }
+futures = { version = "0.3.31", optional = true }
+async-fs = { version = "2.1.2", optional = true }
+tokio-util = { version = "0.7.14", features = ["compat"], optional = true }
+
 directories = "5.0.1"
 
 [dev-dependencies]
 tokio-test = "0.4.4"
+smol = "2.0.2"
+async-fs = { version = "2.1.2" }
+
 
 [package.metadata.docs.rs]
 all-features = true
@@ -34,8 +45,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["asynchronous"]
-asynchronous = ["dep:tokio", "dep:async-mutex"]
+asynchronous = ["dep:tokio", "dep:async-mutex", "dep:futures"]
 allow-unknown = []
 # Enables loading Journal files from before game version 4. Not fully supported and may lead to
 # parsing errors. In such cases, PRs with affected Journal files/events are appreciated :)
 legacy = []
+async-fs = ["dep:async-fs"]

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -2,6 +2,9 @@
 /// all files at once.
 pub mod logs;
 
+/// Module for reading logs using various iterators.
+pub mod io;
+
 /// Allows for tracking journal directory as a whole, firing events for when logs change but also
 /// for when `.json` files are updated.
 pub mod journal;

--- a/src/modules/io/error.rs
+++ b/src/modules/io/error.rs
@@ -8,7 +8,6 @@ pub enum LogError {
     IO(#[from] std::io::Error),
     SerdeJson(#[from] serde_json::Error),
     NotifyError(#[from] notify::Error),
-
     // #[error("Missing file name")]
     // MissingFileName,
 

--- a/src/modules/io/error.rs
+++ b/src/modules/io/error.rs
@@ -1,5 +1,5 @@
-use chrono::ParseError;
-use std::num::ParseIntError;
+// use chrono::ParseError;
+// use std::num::ParseIntError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -9,18 +9,18 @@ pub enum LogError {
     SerdeJson(#[from] serde_json::Error),
     NotifyError(#[from] notify::Error),
 
-    #[error("Missing file name")]
-    MissingFileName,
+    // #[error("Missing file name")]
+    // MissingFileName,
 
-    #[error("Failed to represent file name")]
-    FailedToRepresentOsString,
+    // #[error("Failed to represent file name")]
+    // FailedToRepresentOsString,
 
-    #[error("Incorrect file name")]
-    IncorrectFileName,
+    // #[error("Incorrect file name")]
+    // IncorrectFileName,
 
-    #[error("Failed to parse timestamp of log file")]
-    FailedToParseLogTime(#[source] ParseError),
+    // #[error("Failed to parse timestamp of log file")]
+    // FailedToParseLogTime(#[source] ParseError),
 
-    #[error("Failed to parse part number of log file")]
-    FailedToParsePart(#[source] ParseIntError),
+    // #[error("Failed to parse part number of log file")]
+    // FailedToParsePart(#[source] ParseIntError),
 }

--- a/src/modules/io/error.rs
+++ b/src/modules/io/error.rs
@@ -1,0 +1,26 @@
+use chrono::ParseError;
+use std::num::ParseIntError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[error(transparent)]
+pub enum LogError {
+    IO(#[from] std::io::Error),
+    SerdeJson(#[from] serde_json::Error),
+    NotifyError(#[from] notify::Error),
+
+    #[error("Missing file name")]
+    MissingFileName,
+
+    #[error("Failed to represent file name")]
+    FailedToRepresentOsString,
+
+    #[error("Incorrect file name")]
+    IncorrectFileName,
+
+    #[error("Failed to parse timestamp of log file")]
+    FailedToParseLogTime(#[source] ParseError),
+
+    #[error("Failed to parse part number of log file")]
+    FailedToParsePart(#[source] ParseIntError),
+}

--- a/src/modules/io/mod.rs
+++ b/src/modules/io/mod.rs
@@ -1,0 +1,2 @@
+pub mod error;
+pub mod models;

--- a/src/modules/io/models.rs
+++ b/src/modules/io/models.rs
@@ -1,0 +1,1 @@
+pub mod log_file;

--- a/src/modules/io/models/log_file.rs
+++ b/src/modules/io/models/log_file.rs
@@ -1,0 +1,4 @@
+pub mod log_iter;
+
+#[cfg(feature = "asynchronous")]
+pub mod async_iter;

--- a/src/modules/io/models/log_file/async_iter.rs
+++ b/src/modules/io/models/log_file/async_iter.rs
@@ -1,0 +1,152 @@
+use futures::{AsyncRead, AsyncReadExt, FutureExt, Stream};
+use std::pin::{pin, Pin};
+use std::task::{Context, Poll};
+
+use crate::logs::LogEvent;
+use crate::modules::io::error::LogError;
+
+/// Asynchronous iterator for iterating over some [AsyncRead] and returning [LogEvents](LogEvent).
+pub struct AsyncIter<T>
+where
+    T: AsyncRead + Unpin,
+{
+    inner: T,
+}
+
+impl<T> AsyncIter<T>
+where
+    T: AsyncRead + Unpin,
+{
+    async fn inner_next(&mut self) -> Option<Result<LogEvent, LogError>> {
+        let mut line = Vec::with_capacity(64);
+
+        loop {
+            let mut buf: [u8; 1] = [0; 1];
+            let result = self.inner.read(&mut buf).await;
+
+            match result {
+                Ok(0) => break,
+                Ok(_) => {}
+                Err(e) => return Some(Err(e.into())),
+            }
+
+            let byte = buf[0];
+
+            if byte == b'\n' && !line.is_empty() {
+                break;
+            }
+
+            if byte == 0x00 || (line.is_empty() && byte == b' ') {
+                continue;
+            }
+
+            line.push(byte);
+        }
+
+        if line.is_empty() {
+            return None;
+        }
+
+        Some(Ok(match serde_json::from_slice(&line) {
+            Ok(event) => event,
+            Err(e) => return Some(Err(e.into())),
+        }))
+    }
+}
+
+impl<T> From<T> for AsyncIter<T>
+where
+    T: AsyncRead + Unpin,
+{
+    fn from(inner: T) -> Self {
+        AsyncIter { inner }
+    }
+}
+
+#[cfg(feature = "tokio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
+impl<A> From<A> for AsyncIter<tokio_util::compat::Compat<A>>
+where
+    A: tokio::io::AsyncRead + Unpin,
+{
+    fn from(value: A) -> Self {
+        let compat = tokio_util::compat::TokioAsyncReadCompatExt::compat(value);
+        AsyncIter::from(compat)
+    }
+}
+
+impl<T> Stream for AsyncIter<T>
+where
+    T: AsyncRead + Unpin,
+{
+    type Item = Result<LogEvent, LogError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        pin!(self.inner_next()).poll_unpin(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::logs::LogEventContentKind;
+    use crate::modules::io::models::log_file::async_iter::AsyncIter;
+    use async_fs::File;
+    use futures::io::Cursor;
+    use futures::StreamExt;
+    use smol::fs;
+
+    fn async_reader_reads_complete_file_correctly() {
+        smol::block_on(async {
+            let data = r#"{ "timestamp":"2020-09-21T19:04:44Z", "event":"Repair", "Item":"Paint", "Cost":1 }
+{ "timestamp":"2020-09-21T19:04:51Z", "event":"Repair", "Item":"Wear", "Cost":10 }"#;
+
+            let cursor = Cursor::new(data);
+            let buf_reader = futures::io::BufReader::new(cursor);
+
+            let mut reader = AsyncIter::from(buf_reader);
+
+            assert!(reader.next().await.is_some());
+            assert!(reader.next().await.is_some());
+
+            assert!(dbg!(reader.next().await).is_none());
+        });
+    }
+
+    fn last_lines_are_read_correctly() {
+        smol::block_on(async {
+            fs::write("c.tmp", "").await.unwrap();
+
+            let file = File::open("c.tmp").await.unwrap();
+
+            let buf_reader = futures::io::BufReader::new(file);
+
+            let mut reader = AsyncIter::from(buf_reader);
+
+            assert!(reader.next().await.is_none());
+
+            fs::write(
+                "c.tmp",
+                r#"{"timestamp":"2022-10-22T15:10:41Z","event":"Fileheader","part":1,"language":"English/UK","Odyssey":true,"gameversion":"4.0.0.1450","build":"r286858/r0 "}"#,
+            )
+                .await
+                .unwrap();
+
+            assert_eq!(
+                reader.next().await.unwrap().unwrap().content.kind(),
+                LogEventContentKind::FileHeader
+            );
+
+            fs::write("c.tmp", r#"{"timestamp":"2022-10-22T15:10:41Z","event":"Fileheader","part":1,"language":"English/UK","Odyssey":true,"gameversion":"4.0.0.1450","build":"r286858/r0 "}
+{"timestamp":"2022-10-22T15:12:05Z","event":"Commander","FID":"F123456789","Name":"TEST"}"#)
+                .await
+                .unwrap();
+
+            assert_eq!(
+                reader.next().await.unwrap().unwrap().content.kind(),
+                LogEventContentKind::Commander
+            );
+
+            fs::remove_file("c.tmp").await.unwrap();
+        });
+    }
+}

--- a/src/modules/io/models/log_file/log_iter.rs
+++ b/src/modules/io/models/log_file/log_iter.rs
@@ -1,0 +1,137 @@
+use crate::logs::LogEvent;
+use crate::modules::io::error::LogError;
+use std::io::{Bytes, Read};
+
+/// Standard iterator for iterating over some [Read] and returning [LogEvents](LogEvent).
+#[derive(Debug)]
+pub struct LogIter<T>
+where
+    T: Read,
+{
+    inner: Bytes<T>,
+}
+
+impl<T> From<T> for LogIter<T>
+where
+    T: Read,
+{
+    fn from(value: T) -> Self {
+        LogIter {
+            inner: value.bytes(),
+        }
+    }
+}
+
+impl<T> Iterator for LogIter<T>
+where
+    T: Read,
+{
+    type Item = Result<LogEvent, LogError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut line = Vec::with_capacity(64); // Line are mostly at least 64 bytes
+
+        for byte in self.inner.by_ref() {
+            let byte = match byte {
+                Ok(byte) => byte,
+                Err(e) => return Some(Err(e.into())),
+            };
+
+            if byte == b'\n' && !line.is_empty() {
+                break;
+            }
+
+            if byte == 0x00 || (line.is_empty() && byte == b' ') {
+                continue;
+            }
+
+            line.push(byte);
+        }
+
+        if line.is_empty() {
+            return None;
+        }
+
+        Some(Ok(match serde_json::from_slice(&line) {
+            Ok(event) => event,
+            Err(e) => {
+                #[cfg(test)]
+                dbg!(&line);
+
+                return Some(Err(e.into()));
+            }
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::logs::LogEventContentKind;
+    use crate::modules::io::models::log_file::log_iter::LogIter;
+    use std::fs;
+    use std::fs::File;
+    use std::io::{BufReader, Cursor};
+
+    #[test]
+    fn log_reader_reads_completed_file_correctly() {
+        let data = r#"{ "timestamp":"2020-09-21T19:04:44Z", "event":"Repair", "Item":"Paint", "Cost":1 }
+{ "timestamp":"2020-09-21T19:04:51Z", "event":"Repair", "Item":"Wear", "Cost":10 }"#;
+
+        let cursor = Cursor::new(data);
+        let mut reader = LogIter::from(cursor);
+
+        assert!(reader.next().is_some());
+        assert!(reader.next().is_some());
+
+        assert!(dbg!(reader.next()).is_none());
+    }
+
+    #[test]
+    fn log_reader_handles_trailing_newlines_correctly() {
+        let data = r#"{ "timestamp":"2020-09-21T19:04:44Z", "event":"Repair", "Item":"Paint", "Cost":1 }
+{ "timestamp":"2020-09-21T19:04:51Z", "event":"Repair", "Item":"Wear", "Cost":10 }
+"#;
+
+        let cursor = Cursor::new(data);
+        let mut reader = LogIter::from(cursor);
+
+        assert!(reader.next().is_some());
+        assert!(reader.next().is_some());
+
+        assert!(dbg!(reader.next()).is_none());
+    }
+
+    #[test]
+    fn last_lines_are_read_correctly() {
+        fs::write("c.tmp", "").unwrap();
+        let file = File::open("c.tmp").unwrap();
+        let buf_reader = BufReader::new(file);
+
+        let mut reader = LogIter::from(buf_reader);
+
+        assert!(reader.next().is_none());
+
+        fs::write(
+            "c.tmp",
+            r#"{"timestamp":"2022-10-22T15:10:41Z","event":"Fileheader","part":1,"language":"English/UK","Odyssey":true,"gameversion":"4.0.0.1450","build":"r286858/r0 "}"#,
+        )
+            .unwrap();
+
+        assert_eq!(
+            reader.next().unwrap().unwrap().content.kind(),
+            LogEventContentKind::FileHeader
+        );
+
+        fs::write("c.tmp", r#"{"timestamp":"2022-10-22T15:10:41Z","event":"Fileheader","part":1,"language":"English/UK","Odyssey":true,"gameversion":"4.0.0.1450","build":"r286858/r0 "}
+{"timestamp":"2022-10-22T15:12:05Z","event":"Commander","FID":"F123456789","Name":"TEST"}"#)
+            .unwrap();
+
+        assert_eq!(
+            reader.next().unwrap().unwrap().content.kind(),
+            LogEventContentKind::Commander
+        );
+
+        fs::remove_file("c.tmp").unwrap();
+    }
+}

--- a/src/modules/io/models/log_file/log_iter.rs
+++ b/src/modules/io/models/log_file/log_iter.rs
@@ -16,9 +16,7 @@ where
     T: Read,
 {
     fn from(value: T) -> Self {
-        LogIter {
-            inner: value,
-        }
+        LogIter { inner: value }
     }
 }
 


### PR DESCRIPTION
This moves over async_iter and log_iter from the reader-refactor branch. 
This contains iterators which allow you to iter over a Journal File without blocking at the very end